### PR TITLE
u-boot-fw-utils: Remove patch that is u-boot-2016.1.

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fw-utils%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-fw-utils%.bbappend
@@ -1,7 +1,5 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI += "file://0001-Allow-fw-env-tools-to-be-available-as-library.patch"
-
 do_install_append() {
     install -d ${D}${libdir}
     install -m 644  ${S}/tools/env/lib.a ${D}${libdir}/libubootenv.a


### PR DESCRIPTION
Openembedded-core now has u-boot-2016.1 which has this patch applied.

Signed-off-by: Philip Balister <philip@balister.org>