### PR TITLE
Cherry-pick u-boot-fw-utils fixes from Krogoth to Morty 

### DIFF
--- a/recipes-bsp/u-boot/files/0001-tools-env-bug-config-structs-must-be-defined-in-tool.patch
+++ b/recipes-bsp/u-boot/files/0001-tools-env-bug-config-structs-must-be-defined-in-tool.patch
@@ -1,0 +1,48 @@
+From 43cb65b7a00e4759427a6e4b8a02039e43dab5a5 Mon Sep 17 00:00:00 2001
+From: Andreas Fenkart <andreas.fenkart@digitalstrom.com>
+Date: Fri, 25 Mar 2016 14:52:19 +0100
+Subject: [PATCH] tools: env: bug: config structs must be defined in tools
+ library
+
+fw_senten/fw_printenv can be compiled as a tools library,
+excluding the fw_env_main object.
+
+Reported-by: Stefano Babic <sbabic@denx.de>
+Signed-off-by: Andreas Fenkart <andreas.fenkart@digitalstrom.com>
+---
+ tools/env/fw_env.c      | 4 ++++
+ tools/env/fw_env_main.c | 4 ----
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/tools/env/fw_env.c b/tools/env/fw_env.c
+index 5c7505c..1420ac5 100644
+--- a/tools/env/fw_env.c
++++ b/tools/env/fw_env.c
+@@ -35,6 +35,10 @@
+
+ #include "fw_env.h"
+
++struct common_args common_args;
++struct printenv_args printenv_args;
++struct setenv_args setenv_args;
++
+ #define DIV_ROUND_UP(n, d)	(((n) + (d) - 1) / (d))
+
+ #define min(x, y) ({				\
+diff --git a/tools/env/fw_env_main.c b/tools/env/fw_env_main.c
+index 3bec5b9..3706d8f 100644
+--- a/tools/env/fw_env_main.c
++++ b/tools/env/fw_env_main.c
+@@ -49,10 +49,6 @@ static struct option long_options[] = {
+	{NULL, 0, NULL, 0}
+ };
+
+-struct common_args common_args;
+-struct printenv_args printenv_args;
+-struct setenv_args setenv_args;
+-
+ void usage_printenv(void)
+ {
+
+--
+2.5.5

--- a/recipes-bsp/u-boot/files/0001-tools-env-fix-config-file-loading-in-env-library.patch
+++ b/recipes-bsp/u-boot/files/0001-tools-env-fix-config-file-loading-in-env-library.patch
@@ -1,0 +1,34 @@
+From 925c97c248527391de32c2926f7e1911850fd4b0 Mon Sep 17 00:00:00 2001
+From: Anatolij Gustschin <agust@denx.de>
+Date: Fri, 29 Apr 2016 22:00:11 +0200
+Subject: [PATCH] tools: env: fix config file loading in env library
+
+env library is broken as the config file pointer is only initialized
+in main(). When running in the env library parse_config() fails:
+
+  Cannot parse config file '(null)': Bad address
+
+Ensure that config file pointer is always initialized.
+
+Signed-off-by: Anatolij Gustschin <agust@denx.de>
+Cc: Stefano Babic <sbabic@denx.de>
+---
+ tools/env/fw_env.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/tools/env/fw_env.c b/tools/env/fw_env.c
+index 1420ac5..06cf63d 100644
+--- a/tools/env/fw_env.c
++++ b/tools/env/fw_env.c
+@@ -1325,6 +1325,9 @@ static int parse_config ()
+	struct stat st;
+
+ #if defined(CONFIG_FILE)
++	if (!common_args.config_file)
++		common_args.config_file = CONFIG_FILE;
++
+	/* Fills in DEVNAME(), ENVSIZE(), DEVESIZE(). Or don't. */
+	if (get_config(common_args.config_file)) {
+		fprintf(stderr, "Cannot parse config file '%s': %m\n",
+--
+2.5.5

--- a/recipes-bsp/u-boot/u-boot-fw-utils%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-fw-utils%.bbappend
@@ -1,3 +1,10 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = "\
+    file://0001-tools-env-bug-config-structs-must-be-defined-in-tool.patch \
+    file://0001-tools-env-fix-config-file-loading-in-env-library.patch \
+    "
+
 do_install_append() {
     install -d ${D}${libdir}
     install -m 644  ${S}/tools/env/lib.a ${D}${libdir}/libubootenv.a

--- a/recipes-bsp/u-boot/u-boot-fw-utils%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-fw-utils%.bbappend
@@ -1,10 +1,5 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI_append = "\
-    file://0001-tools-env-bug-config-structs-must-be-defined-in-tool.patch \
-    file://0001-tools-env-fix-config-file-loading-in-env-library.patch \
-    "
-
 do_install_append() {
     install -d ${D}${libdir}
     install -m 644  ${S}/tools/env/lib.a ${D}${libdir}/libubootenv.a

--- a/recipes-bsp/u-boot/u-boot-fw-utils_2016.03.bbappend
+++ b/recipes-bsp/u-boot/u-boot-fw-utils_2016.03.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = "\
+    file://0001-tools-env-bug-config-structs-must-be-defined-in-tool.patch \
+    file://0001-tools-env-fix-config-file-loading-in-env-library.patch \
+    "


### PR DESCRIPTION
Hi @sbabic,

This PR cherry-picks fixes from Krogoth to make u-boot-fw-utils compiles on Morty.

It allows to fix this compilation error:
```
| /home/manoj/fsl-community-bsp/build/tmp/sysroots/nitrogen6x/usr/lib/libubootenv.a(fw_env.o): In function `getenvsize':
| /usr/src/debug/u-boot-fw-utils/v2016.03+gitAUTOINC+df61a74e68-r0/git/tools/env/fw_env.c:131: undefined reference to `common_args'
| /usr/src/debug/u-boot-fw-utils/v2016.03+gitAUTOINC+df61a74e68-r0/git/tools/env/fw_env.c:131: undefined reference to `common_args'
| /home/manoj/fsl-community-bsp/build/tmp/sysroots/nitrogen6x/usr/lib/libubootenv.a(fw_env.o): In function `env_aes_cbc_crypt':
| /usr/src/debug/u-boot-fw-utils/v2016.03+gitAUTOINC+df61a74e68-r0/git/tools/env/fw_env.c:968: undefined reference to `common_args'
| /home/manoj/fsl-community-bsp/build/tmp/sysroots/nitrogen6x/usr/lib/libubootenv.a(fw_env.o): In function `fw_getenv':
| /usr/src/debug/u-boot-fw-utils/v2016.03+gitAUTOINC+df61a74e68-r0/git/tools/env/fw_env.c:161: undefined reference to `common_args'
| /usr/src/debug/u-boot-fw-utils/v2016.03+gitAUTOINC+df61a74e68-r0/git/tools/env/fw_env.c:161: undefined reference to `common_args'
| /home/manoj/fsl-community-bsp/build/tmp/sysroots/nitrogen6x/usr/lib/libubootenv.a(fw_env.o):/usr/src/debug/u-boot-fw-utils/v2016.03+gitAUTOINC+df61a74e68-r0/git/tools/env/fw_env.c:187: more undefined references to `common_args' follow
| /home/manoj/fsl-community-bsp/build/tmp/sysroots/nitrogen6x/usr/lib/libubootenv.a(fw_env.o): In function `fw_printenv':
| /usr/src/debug/u-boot-fw-utils/v2016.03+gitAUTOINC+df61a74e68-r0/git/tools/env/fw_env.c:260: undefined reference to `printenv_args'
| /usr/src/debug/u-boot-fw-utils/v2016.03+gitAUTOINC+df61a74e68-r0/git/tools/env/fw_env.c:260: undefined reference to `printenv_args'
| /usr/src/debug/u-boot-fw-utils/v2016.03+gitAUTOINC+df61a74e68-r0/git/tools/env/fw_env.c:290: undefined reference to `common_args'
| /usr/src/debug/u-boot-fw-utils/v2016.03+gitAUTOINC+df61a74e68-r0/git/tools/env/fw_env.c:290: undefined reference to `common_args'
| /usr/src/debug/u-boot-fw-utils/v2016.03+gitAUTOINC+df61a74e68-r0/git/tools/env/fw_env.c:246: undefined reference to `common_args'
| /usr/src/debug/u-boot-fw-utils/v2016.03+gitAUTOINC+df61a74e68-r0/git/tools/env/fw_env.c:246: undefined reference to `common_args'
| collect2: error: ld returned 1 exit status
```

Georges