### PR TITLE
layer.conf: do not force early expansion of BBFILES

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -1,8 +1,8 @@
 # We have a conf and classes directory, add to BBPATH
-BBPATH := "${BBPATH}:${LAYERDIR}"
+BBPATH .= ":${LAYERDIR}"
 
 # We have a recipes directory, add to BBFILES
-BBFILES := "${BBFILES} ${LAYERDIR}/recipes-*/*/*.bb \
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 	${LAYERDIR}/recipes-*/*/*.bbappend"
 
 BBFILE_COLLECTIONS += "swupdate"


### PR DESCRIPTION
The BBFILES expression is forcing an early expansion which
results in the BBFILE_COLLECTIONS references in BBFILES being
expanded before all the layers were added to it.

Signed-off-by: Chris Larson <Chris_Larson@mentor.com>
Tested-by: Cedric Hombourger <Cedric_Hombourger@mentor.com>