### PR TITLE
swupdate : fixed install of 2017.01

### DIFF
--- a/recipes-support/swupdate/swupdate.inc
+++ b/recipes-support/swupdate/swupdate.inc
@@ -123,12 +123,6 @@ do_install () {
 
   install -d ${D}${systemd_unitdir}/system
   install -m 644 ${WORKDIR}/swupdate.service ${D}${systemd_unitdir}/system
-  install -m 644 ${WORKDIR}/swupdate-usb@.service ${D}${systemd_unitdir}/system
-  install -m 644 ${WORKDIR}/swupdate-progress.service ${D}${systemd_unitdir}/system
-  if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
-    install -d ${D}${sysconfdir}/udev/rules.d
-    install -m 0644 ${WORKDIR}/swupdate-usb.rules ${D}${sysconfdir}/udev/rules.d/
-  fi
 }
 
 INITSCRIPT_NAME = "swupdate"

--- a/recipes-support/swupdate/swupdate_git.bb
+++ b/recipes-support/swupdate/swupdate_git.bb
@@ -15,3 +15,13 @@ do_compile_append() {
   oe_runmake
   unset LDFLAGS
 }
+
+do_install_append () {
+  install -d ${D}${systemd_unitdir}/system
+  install -m 644 ${WORKDIR}/swupdate-usb@.service ${D}${systemd_unitdir}/system
+  install -m 644 ${WORKDIR}/swupdate-progress.service ${D}${systemd_unitdir}/system
+  if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+    install -d ${D}${sysconfdir}/udev/rules.d
+    install -m 0644 ${WORKDIR}/swupdate-usb.rules ${D}${sysconfdir}/udev/rules.d/
+  fi
+}


### PR DESCRIPTION
the do_install in the swupdate.inc installs the new swupdate services but the service files are present in SRC_URI only for swupdate_git.bb.
I don't really know if the best would be to get service files in 2017.01 or in the git. As there was a doubt I left everything in the swupdate_git.bb.