### PR TITLE
add swupdate specific systemd-tmpfiles configuration file

### DIFF
--- a/recipes-support/swupdate/swupdate.inc
+++ b/recipes-support/swupdate/swupdate.inc
@@ -14,6 +14,7 @@ SRC_URI = "git://github.com/sbabic/swupdate.git;protocol=https \
      file://swupdate-usb.rules \
      file://swupdate-usb@.service \
      file://swupdate-progress.service \
+     file://systemd-tmpfiles-swupdate.conf \
      "
 
 INSANE_SKIP_${PN} = "ldflags"
@@ -133,6 +134,8 @@ do_install () {
 
 
   if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+    install -d ${D}${libdir}/tmpfiles.d
+    install -m 0644 ${WORKDIR}/systemd-tmpfiles-swupdate.conf ${D}${libdir}/tmpfiles.d/swupdate.conf
     install -d ${D}${sysconfdir}/udev/rules.d
     install -m 0644 ${WORKDIR}/swupdate-usb.rules ${D}${sysconfdir}/udev/rules.d/
   fi

--- a/recipes-support/swupdate/swupdate/systemd-tmpfiles-swupdate.conf
+++ b/recipes-support/swupdate/swupdate/systemd-tmpfiles-swupdate.conf
@@ -1,0 +1,2 @@
+X /tmp/datadst
+X /tmp/scripts


### PR DESCRIPTION
The default systemd-tmpfiles configuration for the /tmp directory
(tmp.conf) causes systemd-tmpfiles-clean.service to remove the folders
/tmp/datadst and /tmp/scripts if they are not used for >=10 days.

SWUpdate creates these directories on startup (swupdate_init) and
assumes their existence on use.

For this reason, an SWUpdate specific systemd-tmpfiles configuration
is installed, in order to guarantee that the two directores above
are preserved (only the folders, not their content).