### PR TITLE
u-boot-fw-utils append, libubootenv_0.2 removed from poky

### DIFF
--- a/recipes-bsp/libubootenv/libubootenv_0.2.bb
+++ b/recipes-bsp/libubootenv/libubootenv_0.2.bb
@@ -1,2 +1,0 @@
-require libubootenv.inc
-SRCREV = "bf6ff631c0e38cede67268ceb8bf1383b5f8848e"

--- a/recipes-bsp/u-boot/u-boot-fw-utils%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-fw-utils%.bbappend
@@ -1,4 +1,0 @@
-do_install_append() {
-    install -d ${D}${libdir}
-    install -m 644  ${S}/tools/env/lib.a ${D}${libdir}/libubootenv.a
-}


### PR DESCRIPTION
main u-boot-fw-utils.bb removed from poky: https://git.yoctoproject.org/cgit.cgi/poky/commit/meta/recipes-bsp/u-boot?id=3c5a8bf487a9d52691529c35420bd38a321fbc2a
main libubootenv.bb added in poky: https://git.yoctoproject.org/cgit.cgi/poky/commit/meta/recipes-bsp/u-boot?id=cfdaad287b8bfe6909acc0257d120c58abe8ae5e

Signed-off-by: Darko Komljenovic <dkomljenovic@zoho.com>