### PR TITLE
mtd-utils: remove conflicting patch

### DIFF
--- a/recipes-devtools/mtd/mtd-utils_%.bbappend
+++ b/recipes-devtools/mtd/mtd-utils_%.bbappend
@@ -2,6 +2,9 @@ FILES_${PN}-staticdev += "ubi-utils/libubi.a ${libdir}/*.a"
 
 SRCREV = "639b871fe3d2cb3e73d21363e8c13ede2bbd9f99"
 
+# remove patch from meta layer that has already been applied with this SRCREV
+SRC_URI_remove = "file://0001-mtd-utils-Fix-return-value-of-ubiformat.patch"
+
 do_install_append () {
 	install -d ${D}${includedir}/mtd/
 	install -d ${D}${libdir}/


### PR DESCRIPTION
current version of recipe in meta layer attempts to apply patch
0001-mtd-utils-Fix-return-value-of-ubiformat.patch which contains
changes that have already been applied in the mtd-utils version
selected by this bbappend

Signed-off-by: S. Lockwood-Childs <sjl@vctlabs.com>