### PR TITLE
Fix error message when SWUPDATE_AES_FILE is not found or valid

### DIFF
--- a/classes/swupdate-enc.bbclass
+++ b/classes/swupdate-enc.bbclass
@@ -12,7 +12,7 @@ swu_encrypt_file() {
 	key=`cat ${SWUPDATE_AES_FILE} | grep ^key | cut -d '=' -f 2`
 	iv=`cat ${SWUPDATE_AES_FILE} | grep ^iv | cut -d '=' -f 2`
 	if [ -z ${key} ] || [ -z ${iv} ];then
-		bbfatal "SWUPDATE_AES_FILE=$SWUPDATE_AES_FILE does not contain valid keys"
+		bbfatal "SWUPDATE_AES_FILE=${SWUPDATE_AES_FILE} does not contain valid keys"
 	fi
 	openssl enc -aes-256-cbc -in ${input} -out ${output} -K ${key} -iv ${iv} -nosalt
 }


### PR DESCRIPTION
The previous syntax always prints an empty string.