### PR TITLE
Fix ALLOW_EMPTY assignments in swupdate.inc

### DIFF
--- a/recipes-support/swupdate/swupdate.inc
+++ b/recipes-support/swupdate/swupdate.inc
@@ -47,8 +47,8 @@ wwwdir ?= "/www"
 
 # tools is now an empty meta package for backward compatibility
 ALLOW_EMPTY_${PN}-tools = "1"
-+ALLOW_EMPTY_${PN}-tools-hawkbit = "1"
-+ALLOW_EMPTY_${PN}-tools-ipc = "1"
+ALLOW_EMPTY_${PN}-tools-hawkbit = "1"
+ALLOW_EMPTY_${PN}-tools-ipc = "1"
 
 FILES_${PN}-client = "${bindir}/swupdate-client"
 FILES_${PN}-lua += "${libdir}/lua/"


### PR DESCRIPTION
Remove the spurious "+" characters at the beginning of the ALLOW_EMPTY
overrides for the swupdate-tools-hawkbit and swupdate-tools-ipc packages.
