### PR TITLE
swupdate-common: fix sha256 regex

### DIFF
--- a/classes/swupdate-common.bbclass
+++ b/classes/swupdate-common.bbclass
@@ -81,7 +81,7 @@ def swupdate_write_sha256(s):
        for line in f:
           shastr = r"sha256.+=.+@(.+\")"
           #m = re.match(r"^(?P<before_placeholder>.+)sha256.+=.+(?P<filename>\w+)", line)
-          m = re.match(r"^(?P<before_placeholder>.+)[sha256|version].+[=:].*(?P<quote>[\'\"])@(?P<filename>.*)(?P=quote)", line)
+          m = re.match(r"^(?P<before_placeholder>.+)(sha256|version).+[=:].*(?P<quote>[\'\"])@(?P<filename>.*)(?P=quote)", line)
           if m:
               filename = m.group('filename')
               hash = swupdate_get_sha256(s, filename)


### PR DESCRIPTION
Change sha256 regex brackets to parenthesis to apply only on line with 'sha256'
and 'version'.
