### PR TITLE
Fix/sstate handling

### DIFF
--- a/classes/swupdate-common.bbclass
+++ b/classes/swupdate-common.bbclass
@@ -11,7 +11,7 @@ DEPENDS += "\
 
 do_swuimage[umask] = "022"
 SSTATETASKS += "do_swuimage"
-SSTATE_SKIP_CREATION_task-swuimage = '1'
+SSTATE_SKIP_CREATION:task-swuimage = '1'
 SWUDEPLOYDIR = "${WORKDIR}/deploy-${PN}-swuimage"
 
 do_swuimage[dirs] = "${SWUDEPLOYDIR}"

--- a/classes/swupdate-image.bbclass
+++ b/classes/swupdate-image.bbclass
@@ -51,6 +51,12 @@ python do_swupdate_copy_swdescription() {
 addtask swupdate_copy_swdescription before do_image_complete after do_unpack
 addtask swuimage after do_swupdate_copy_swdescription do_image_complete before do_build
 
+# define setscene task
+python do_swuimage_setscene () {
+    sstate_setscene(d)
+}
+addtask do_swuimage_setscene
+
 # Read all variables from sw-description file and add them to the vardeps of the do_swuimage task. Bitbake
 # cannot know that the do_swuimage task which evaluates the templated sw-description file needs to be executed
 # if a variable which is refered by the sw-description file but not by the recipe itself.


### PR DESCRIPTION
Old override syntax is causing huge sstate objects.
Fixing the override correctly skips sstate blob creation.

Additionally during review of the sstate handling I found out that setscene function is missing.
I'm actually not quite sure why it's needed as my images are always rebuilt, but all image classes using sstate in poky have this.
Feel free to move it to other class, I put it just next to the other addtask clauses.

Please cherry-pick this to kirkstone after merging.