### PR TITLE
swupdate-enc: Convert CONVERSION_CMD to new override syntax

### DIFF
--- a/classes/swupdate-enc.bbclass
+++ b/classes/swupdate-enc.bbclass
@@ -20,4 +20,4 @@ swu_encrypt_file() {
 CONVERSIONTYPES += "enc"
 
 CONVERSION_DEPENDS_enc = "openssl-native coreutils-native"
-CONVERSION_CMD_enc="swu_encrypt_file ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type} ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type}.enc"
+CONVERSION_CMD:enc="swu_encrypt_file ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type} ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type}.enc"


### PR DESCRIPTION
swupdate-enc is broken in kirkstone due to lack of inclusion of the change to the new override syntax for CONVERSION_CMD.

Cherry-pick the relevant fix from the langdale branch.