### PR TITLE
Update BitBake auto versions

### DIFF
--- a/README
+++ b/README
@@ -28,20 +28,13 @@ pass $swupdate_get_sha256(IMAGE) (where IMAGE is an image filename).
 BitBake auto versions
 ---------------------
 
-By setting the version tag in the update file to `@SWU_AUTO_VERSION` it is
+By setting the version tag in the update file to `$swupdate_get_pkgvar(<package-name>)` it is
 automatically replaced with `PV` from BitBake's package-data-file for the package
-matching the name of the provided filename tag.
-
-Since the filename can differ from package name (deployed with another name or
-the file is a container for the real package) you can append the correct package
-name to the tag:
-`@SWU_AUTO_VERSION:<package-name>`
+matching the name of the provided <package-name> tag.
 
 To insert the value of a variable from BitBake's package-data-file different to
 `PV` (e.g. `PKGV`) you can append the variable name to the tag:
-`@SWU_AUTO_VERSION@<package-data-variable>`
-or
-`@SWU_AUTO_VERSION:<package-name>@<package-data-variable>`
+`$swupdate_get_pkgvar(<package-name>@<package-data-variable>)`
 
 SWU image signing
 -----------------


### PR DESCRIPTION
Some time ago the aforementioned SWU_AUTO_VERSION was removed and is replaced with a function call to swupdate_get_pkgvar

This information is also wrong in the main swupdate documentation.