### PR TITLE
swupdate: Enable systemd based on distro feature

### DIFF
--- a/recipes-support/swupdate/swupdate.inc
+++ b/recipes-support/swupdate/swupdate.inc
@@ -148,7 +148,7 @@ python () {
     if 'CONFIG_JSON=y\n' in features:
         depends += ' json-c'
 
-    if 'CONFIG_SYSTEMD=y\n' in features:
+    if 'CONFIG_SYSTEMD=y\n' in features or bb.utils.contains('DISTRO_FEATURES', 'systemd', True, False ,d):
         depends += ' systemd'
 
     if 'CONFIG_ARCHIVE=y\n' in features:
@@ -243,6 +243,14 @@ python () {
             if swver_file != "":
                d.setVar('SWUPDATE_SW_VERSIONS_FILE', swver_file)
 }
+
+# in case systemd is set as a distro feature this will add it to the defconfig
+update_config_systemd(){
+    if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+        sed -i -e 's/# CONFIG_SYSTEMD is not set/CONFIG_SYSTEMD=y/g' ${WORKDIR}/defconfig;
+    fi
+}
+do_configure[prefuncs] += "update_config_systemd"
 
 do_configure () {
     cat > ${WORKDIR}/.config <<HEREDOC


### PR DESCRIPTION
When systemd distro feature is enabled, CONFIG_SYSTEMD must be enabled in order for the swupdate.service to actually work.
Before this change, a custom defconfig was required in order to use with systemd distro feature, which probably has caused some surprise to many people.