### PR TITLE
recipes-support: swupdate.sh: improve handling of quoted arguments

### DIFF
--- a/recipes-support/swupdate/swupdate/swupdate.sh
+++ b/recipes-support/swupdate/swupdate/swupdate.sh
@@ -16,13 +16,14 @@ for f in `(test -d @LIBDIR@/swupdate/conf.d/ && ls -1 @LIBDIR@/swupdate/conf.d/;
   fi
 done
 
-#  handle variable escaping in a simmple way. Use exec to forward open filedescriptors from systemd open.
-if [ "$SWUPDATE_WEBSERVER_ARGS" != "" -a  "$SWUPDATE_SURICATTA_ARGS" != "" ]; then
-  exec /usr/bin/swupdate $SWUPDATE_ARGS -w "$SWUPDATE_WEBSERVER_ARGS" -u "$SWUPDATE_SURICATTA_ARGS"
-elif [ "$SWUPDATE_WEBSERVER_ARGS" != "" ]; then
-  exec /usr/bin/swupdate $SWUPDATE_ARGS -w "$SWUPDATE_WEBSERVER_ARGS"
-elif [ "$SWUPDATE_SURICATTA_ARGS" != "" ]; then
-  exec /usr/bin/swupdate $SWUPDATE_ARGS -u "$SWUPDATE_SURICATTA_ARGS"
-else
-  exec /usr/bin/swupdate $SWUPDATE_ARGS
+if [ "${SWUPDATE_WEBSERVER_ARGS}" != "" ]; then
+  SWUPDATE_ARGS="${SWUPDATE_ARGS} -w '${SWUPDATE_WEBSERVER_ARGS}'"
 fi
+
+if [ "${SWUPDATE_SURICATTA_ARGS}" != "" ]; then
+  SWUPDATE_ARGS="${SWUPDATE_ARGS} -u '${SWUPDATE_SURICATTA_ARGS}'"
+fi
+
+# Handle shell command arguments using eval to get expected effect from quoting
+# Use exec to forward open filedescriptors from systemd open.
+eval exec /usr/bin/swupdate ${SWUPDATE_ARGS}


### PR DESCRIPTION
Attempting to set the downloader arguments via SWUPDATE_EXTRA_ARGS in the swupdate systemd service file fails:

```
    [Service]
    Environment="SWUPDATE_EXTRA_ARGS=-d '-r 3'"
```

Due to the way the swupdate binary is invoked, the resulting command line arguments for swupdate end up as:

```
  argv[1] = "-v"     # set in the swupdate.sh script
  argv[2] = "-d"     # here comes SWUPDATE_EXTRA_ARGS
  argv[3] = "'-r"    # not the expected behaviour from quotes
  argv[4] = "3'"
```

If swupdate is invoked with "eval exec" instead of "exec", we get the expected behaviour from quotes:

```
  argv[1] = "-v"     # set in the swupdate.sh script
  argv[2] = "-d"     # here comes SWUPDATE_EXTRA_ARGS
  argv[3] = "-r 3"   # expected behaviour from quotes
```

The explicit invocation of swupdate when SWUPDATE_WEBSERVER_ARGS or SWUPDATE_SURICATTA_ARGS are set, is probably for the same reason. Simplify these as "eval exec" will also give the expected behaviour for these arguments.