### PR TITLE
fix header names in zckheader function.

### DIFF
--- a/classes-recipe/image_types_zchunk.bbclass
+++ b/classes-recipe/image_types_zchunk.bbclass
@@ -1,7 +1,7 @@
 CONVERSIONTYPES += "zck zckheader"
 
 CONVERSION_CMD:zck = "zck --output ${IMAGE_NAME}.${type}.zck -u --chunk-hash-type sha256 ${IMAGE_NAME}.${type}"
-CONVERSION_CMD:zckheader = "dd if=${IMAGE_NAME}.${type} of=${IMAGE_NAME}.${type}.zckheader count=1 bs=`zck_read_header -v ${IMAGE_NAME}.${type} | grep 'Header size' | cut -d ':' -f 2 | tr -d '[:space:]'`"
+CONVERSION_CMD:zckheader = "dd if=${IMAGE_NAME}.${type}.zck of=${IMAGE_NAME}.${type}.zckheader count=1 bs=`zck_read_header -v ${IMAGE_NAME}.${type}.zck | grep 'Header size' | cut -d ':' -f 2 | tr -d '[:space:]'`"
 
 CONVERSION_DEPENDS_zck = "zchunk-native"
 CONVERSION_DEPENDS_zckheader = "zchunk-native"


### PR DESCRIPTION
The original cmd generated an error due to name convension Problem. This new naming have preserved the original Image and also generated new .zck files. As normally in Yocto we normally need the Original Image and generating  .zck would not be the main Thing in the Project. 