### PR TITLE
Convert licenses to SPDX expressions

### DIFF
--- a/recipes-support/swupdate/swupdate.inc
+++ b/recipes-support/swupdate/swupdate.inc
@@ -7,10 +7,10 @@ DEPENDS += "libconfig zlib libubootenv json-c"
 # SWUpdate licensing is described in the following pages:
 # https://sbabic.github.io/swupdate/licensing.html
 # rst form: file://doc/source/licensing.rst
-LICENSE = "GPL-2.0-only & GPL-2.0-or-later & LGPL-2.1-or-later & LGPL-2.1-only & MIT & ISC & BSD-1-Clause & BSD-3-Clause & OFL-1.1"
+LICENSE = "GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later AND LGPL-2.1-only AND MIT AND ISC AND BSD-1-Clause AND BSD-3-Clause AND OFL-1.1"
 LICENSE:${PN}-ipc = "LGPL-2.1-or-later"
-LICENSE:${PN}-lua = "LGPL-2.1-only & MIT"
-LICENSE:${PN}-www = "MIT & OFL-1.1"
+LICENSE:${PN}-lua = "LGPL-2.1-only AND MIT"
+LICENSE:${PN}-www = "MIT AND OFL-1.1"
 
 LIC_FILES_CHKSUM = " \
     file://LICENSES/BSD-1-Clause.txt;md5=4c75b3902cf6a01969906bcae9cf8cd6 \


### PR DESCRIPTION
openembedded-core recently has introduced more strict SPDX checks. That caused warnings, so we chase the upstream and fix them.
